### PR TITLE
Fixed localization error that caused incorrect parsing of floats.

### DIFF
--- a/SVM/Programs/Programs/ifthenelse.svm
+++ b/SVM/Programs/Programs/ifthenelse.svm
@@ -23,6 +23,8 @@ sub reg1 1
 //skip the else block 
 jmp endif
 #else
+//move back x into reg1 (it has been overwritten)
+mov reg1 [15]
 // x += 1
 add reg1 1
 #endif

--- a/SVM/Programs/Programs/initList.svm
+++ b/SVM/Programs/Programs/initList.svm
@@ -1,5 +1,8 @@
 ﻿/* initialize a list of 10 elements set to -1 */
 
+//start counter with 0
+mov reg2 0
+
 #loop
 mov reg1 reg2
 add reg1 10

--- a/SVM/SVMParser/Lexer.fs
+++ b/SVM/SVMParser/Lexer.fs
@@ -366,7 +366,7 @@ and _fslex_tokenstream  _fslex_state lexbuf =
           )
   | 28 -> ( 
 # 64 "Lexer.fsl"
-                                                               Parser.FLOAT (Double.Parse(LexBuffer<_>.LexemeString lexbuf),(range lexbuf)) 
+                                                               Parser.FLOAT (Double.Parse(LexBuffer<_>.LexemeString lexbuf, System.Globalization.CultureInfo.InvariantCulture),(range lexbuf)) 
 # 370 "Lexer.fs"
           )
   | 29 -> ( 

--- a/SVM/SVMParser/Lexer.fsl
+++ b/SVM/SVMParser/Lexer.fsl
@@ -61,7 +61,7 @@ and tokenstream = parse
 | "jeq" { Parser.JEQ (range lexbuf) }
 | eof   	{ Parser.EOF }
 | ['-']?digit+   { Parser.INT (Int32.Parse(LexBuffer<_>.LexemeString lexbuf),(range lexbuf)) }
-| ['-']?digit+('.'digit+)?(['e''E']digit+)?   { Parser.FLOAT (Double.Parse(LexBuffer<_>.LexemeString lexbuf),(range lexbuf)) }
+| ['-']?digit+('.'digit+)?(['e''E']digit+)?   { Parser.FLOAT (Double.Parse(LexBuffer<_>.LexemeString lexbuf, System.Globalization.CultureInfo.InvariantCulture),(range lexbuf)) } //['-']?digit+('.'digit+)?(['e''E']digit+)?   { Parser.FLOAT (Double.Parse(LexBuffer<_>.LexemeString lexbuf),(range lexbuf)) } <-originals
 | "\"" [^'"']* "\"" { let s = LexBuffer<_>.LexemeString lexbuf in Parser.STRING ((s.Trim [|'\"'|]),(range lexbuf)) }
 | Id { Parser.ID((LexBuffer<_>.LexemeString lexbuf),range lexbuf) }
 | _    		{


### PR DESCRIPTION
Float was parsed wrongly on machines with a locale that treats commas as decimal seperators. This fix makes the parse culture invariant, ensuring that floats are correctly parsed.