### PR TITLE
Fixed mistake in SVM program"ifthenelse.svm"

### DIFF
--- a/SVM/Programs/Programs/ifthenelse.svm
+++ b/SVM/Programs/Programs/ifthenelse.svm
@@ -23,6 +23,8 @@ sub reg1 1
 //skip the else block 
 jmp endif
 #else
+//move back x into reg1 (it has been overwritten)
+mov reg1 [15]
 // x += 1
 add reg1 1
 #endif


### PR DESCRIPTION
Program didn't move back value from [15] to Reg1, resulting in the answer always being 1 if the starting value was <=0. Program now correctly moves back the value in the else block, just like it does in the if block.